### PR TITLE
Use query string params for auth

### DIFF
--- a/butterfly/routes.py
+++ b/butterfly/routes.py
@@ -100,8 +100,11 @@ def require_basic_auth(handler_class):
         # be a good place to see if you like their username and
         # password.)
         def require_basic_auth(handler, kwargs):
-            auth_header = handler.request.headers.get('Authorization')
-            if auth_header is None or not auth_header.startswith('Basic '):
+            username = handler.request.GET.get('u')
+            password = handler.request.GET.get('p')
+            # auth_header = handler.request.headers.get('Authorization')
+            # if auth_header is None or not auth_header.startswith('Basic '):
+            if username is None or password is None
                 # If the browser didn't send us authorization headers,
                 # send back a response letting it know that we'd like
                 # a username and password (the "Basic" authentication
@@ -120,8 +123,8 @@ def require_basic_auth(handler_class):
             # Keep in mind that either username or password could
             # still be unset, and that you should check to make sure
             # they reflect valid credentials!
-            auth_decoded = base64.decodestring(auth_header[6:])
-            username, password = auth_decoded.split(':', 2)
+            # auth_decoded = base64.decodestring(auth_header[6:])
+            # username, password = auth_decoded.split(':', 2)
             kwargs['basicauth_user'], kwargs['basicauth_pass'] = username, password
             return True
 


### PR DESCRIPTION
The url-based http Basic authorization that was
used for authrorizing accesses to Sense terminal
is deprecated in HTTP specs and causes Safari
to show "Possible Phishing Site" warning when
attempting to open a terminal window.

The changes in this commit are to prevent this
warning to show up. Instead of using Basic
authorization like:

https://sense:{password}@tty-{console_id}.sensegrid.com

, we pass username and password as query string
parameters like:

https://tty-{console_id}.sensegrid.com?u=sense&p={password}

Note that the keys for username and password are
'u' and 'p', respectively.
